### PR TITLE
Added try/catch in JSON.parse

### DIFF
--- a/lib/W3W.Geocoder.js
+++ b/lib/W3W.Geocoder.js
@@ -260,7 +260,7 @@ Geocoder.prototype.execute = function(method, params) {
             qs: finalParams
         };
 
-        request.get(options, function(error, response, body) {
+        request.get(options, function(error, response) {
             if (error) {
                 reject({
                     code: 404,
@@ -275,13 +275,15 @@ Geocoder.prototype.execute = function(method, params) {
                 } else if (response.body.error) {
                     reject(response.body);
                 }
-                if (body) {
-                    if (params.format && params.format.toLowerCase() !== 'json') {
+                if (response.body) {
+
+                    var format = params.format;
+
+                    if (format && format.toLowerCase() !== 'json' || format.toLowerCase() !== 'geojson' ) {
                         resolve(response.body);
                     } else {
                         try {
-                          body = JSON.parse(response.body);
-                          resolve(body);
+                          resolve(JSON.parse(response.body));
                         } catch (err) {
                           reject({code: 500, msg: err});
                         }

--- a/lib/W3W.Geocoder.js
+++ b/lib/W3W.Geocoder.js
@@ -279,7 +279,7 @@ Geocoder.prototype.execute = function(method, params) {
 
                     var format = params.format;
 
-                    if (format && format.toLowerCase() !== 'json' || format.toLowerCase() !== 'geojson' ) {
+                    if (format && (format.toLowerCase() !== 'json' || format.toLowerCase() !== 'geojson')) {
                         resolve(response.body);
                     } else {
                         try {

--- a/lib/W3W.Geocoder.js
+++ b/lib/W3W.Geocoder.js
@@ -279,7 +279,12 @@ Geocoder.prototype.execute = function(method, params) {
                     if (params.format && params.format.toLowerCase() !== 'json') {
                         resolve(response.body);
                     } else {
-                        resolve(JSON.parse(response.body));
+                        try {
+                          body = JSON.parse(response.body);
+                          resolve(body);
+                        } catch (err) {
+                          reject({code: 500, msg: err});
+                        }
                     }
                 }
             }


### PR DESCRIPTION
It is necessary to wrap the JSON.parse in a try/catch. In some cases the endpoint answers w/ html, this will crash the library:

```
<html>
^
SyntaxError: Unexpected token <
    at Object.parse (native)
[import]    at Request._callback (/bundle/bundle/programs/server/npm/node_modules/w3w-node-wrapper/lib/W3W.Geocoder.js:282:38)
    at Request.self.callback (/bundle/bundle/programs/server/npm/node_modules/request/request.js:186:22)
    at emitTwo (events.js:87:13)
    at Request.emit (events.js:172:7)
```
