### PR TITLE
[TT-6297] Only call autosuggest-selection for w3w whitelisted domains

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@what3words/api",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "what3words javascript api",
   "engines": {
     "node": ">=8"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -29,7 +29,7 @@
     "url": "git+https://github.com/what3words/w3w-node-wrapper.git"
   },
   "sideEffects": false,
-  "version": "3.3.2",
+  "version": "3.3.3",
   "peerDependencies": {
     "axios": "^0.19.0"
   }

--- a/src/requests/autosuggest-selection.ts
+++ b/src/requests/autosuggest-selection.ts
@@ -1,4 +1,5 @@
 import { fetchGet } from '../fetch'
+import { getOptions } from '../utils';
 import { AutosuggestOptions, autosuggestOptionsToQuery } from './autosuggest'
 
 export const autosuggestSelection = (
@@ -8,6 +9,9 @@ export const autosuggestSelection = (
   options: AutosuggestOptions = {},
   sourceApi: 'text' | 'voice' = 'text',
 ): Promise<null> => {
+  const W3W_DOMAIN_REGEX = /^[\w.-_]*.(what3words.com|w3w.io){1}/ig
+  const baseUrl = getOptions().baseUrl
+  if (baseUrl && !W3W_DOMAIN_REGEX.test(baseUrl)) return Promise.resolve(null)
   return fetchGet("autosuggest-selection", {
     'raw-input': rawInput,
     selection,

--- a/src/requests/autosuggest-selection.ts
+++ b/src/requests/autosuggest-selection.ts
@@ -9,7 +9,7 @@ export const autosuggestSelection = (
   options: AutosuggestOptions = {},
   sourceApi: 'text' | 'voice' = 'text',
 ): Promise<null> => {
-  const W3W_DOMAIN_REGEX = /^[\w.-_]*.(what3words.com|w3w.io){1}/ig
+  const W3W_DOMAIN_REGEX = /(what3words.com|w3w.io)/ig
   const baseUrl = getOptions().baseUrl
   if (baseUrl && !W3W_DOMAIN_REGEX.test(baseUrl)) return Promise.resolve(null)
   return fetchGet("autosuggest-selection", {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '3.3.2';
+export const version = '3.3.3';


### PR DESCRIPTION
## Background
Turns out that the Enterprise API that is distributed to clients to run their own w3w API infrastructure does not include the `autosuggest-selection` endpoint. In order to fix 404s that are thrown in this use case I have added a whitelist of domains that support this call otherwise it just does nothing.

- Adds a whitelist for domains that support the `autosuggest-selection` endpoint and does not call it if it is not a w3w domain that supports this request.
