### PR TITLE
Resolve client import error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@what3words/api",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "what3words JavaScript API",
   "homepage": "https://github.com/what3words/w3w-node-wrapper#readme",
   "main": "dist/index.js",

--- a/src/lib/transport/model.ts
+++ b/src/lib/transport/model.ts
@@ -6,7 +6,7 @@ import {
   GridSectionJsonResponse,
   LocationGeoJsonResponse,
   LocationJsonResponse,
-} from 'client';
+} from '../../client';
 import { ClientRequest } from '../client';
 
 export type Transport = <


### PR DESCRIPTION
Current package fails to import `client`, shown below:
```bash
../javascript/node_modules/@what3words/api/dist/lib/transport/model.d.ts:1:192 - error TS2307: Cannot find module 'client' or its corresponding type declarations.

1 import { AutosuggestResponse, AvailableLanguagesResponse, FeatureCollectionResponse, GridSectionGeoJsonResponse, GridSectionJsonResponse, LocationGeoJsonResponse, LocationJsonResponse } from 'client';
                                                                                                                                                                                                 ~~~~~~~~
```