### PR TITLE
[IN-316]: Update headers constant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@what3words/api",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@what3words/api",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
         "@testing-library/react": "^12.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@what3words/api",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "what3words JavaScript API",
   "homepage": "https://github.com/what3words/w3w-node-wrapper#readme",
   "main": "dist/index.js",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,7 +6,7 @@ export const W3W_REGEX =
 export const VERSION = '__VERSION__';
 export const HEADERS = {
   'X-W3W-Wrapper':
-    typeof process === 'undefined'
+    typeof window !== 'undefined'
       ? `what3words-JavaScript/${VERSION} (${window.navigator.userAgent})`
       : `what3words-Node/${VERSION} (Node ${process.version}; ${getPlatform(
           platform()


### PR DESCRIPTION
# Problem 

The Node Wrapper is currently not compatible with react native because it uses process.
```shell
 ERROR  TypeError: undefined is not a function, js engine: hermes
```

# Fix

```typescript
export const HEADERS = {
  'X-W3W-Wrapper':
    typeof window !== 'undefined'
      ? `what3words-JavaScript/${VERSION} (${window.navigator.userAgent})`
      : `what3words-Node/${VERSION} (Node ${process.version}; ${getPlatform(
          platform()
        )} ${release()})`,
};
```