### PR TITLE
[IN-6] Remove user agent from x-w3w-wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@what3words/api",
-  "version": "5.3.0-alpha.0",
+  "version": "5.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@what3words/api",
-      "version": "5.3.0-alpha.0",
+      "version": "5.3.0",
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
         "@testing-library/react": "^12.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@what3words/api",
-  "version": "5.2.0",
+  "version": "5.3.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@what3words/api",
-      "version": "5.2.0",
+      "version": "5.3.0-alpha.0",
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
         "@testing-library/react": "^12.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@what3words/api",
-  "version": "5.2.0",
+  "version": "5.3.0-alpha.0",
   "description": "what3words JavaScript API",
   "homepage": "https://github.com/what3words/w3w-node-wrapper#readme",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@what3words/api",
-  "version": "5.3.0-alpha.0",
+  "version": "5.3.0",
   "description": "what3words JavaScript API",
   "homepage": "https://github.com/what3words/w3w-node-wrapper#readme",
   "main": "dist/index.js",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,7 +18,7 @@ export const VERSION = '__VERSION__';
 export const HEADERS = {
   'X-W3W-Wrapper':
     typeof window !== 'undefined'
-      ? `what3words-JavaScript/${VERSION} (${window.navigator.userAgent})`
+      ? `what3words-JavaScript/${VERSION}`
       : `what3words-Node/${VERSION} (Node ${process.version}; ${getPlatform(
           platform()
         )} ${release()})`,


### PR DESCRIPTION
Passing user-agent info on the x-w3w-wrapper header is redundant since we can get this information from the `User-Agent` header itself.